### PR TITLE
Updated NestedCountOfTests, DepthCountOfTests, InDataStructureTests, …

### DIFF
--- a/Source/IExpressions.cls
+++ b/Source/IExpressions.cls
@@ -77,7 +77,8 @@ Public Sub addToTestAndFluentPath( _
     Optional ByVal higherVal As Variant, _
     Optional ByVal cleanedTestValue As Variant, _
     Optional ByVal cleanedTestInput As Variant, _
-    Optional ByVal Actual As Variant _
+    Optional ByVal Actual As Variant, _
+    Optional ByVal recurIterFunc As Variant _
 )
 End Sub
 
@@ -111,7 +112,7 @@ End Function
 Public Sub addFluentPathNew(ByVal test As ITest, ByVal negateValue As Boolean)
 End Sub
 
-Public Function InputToString(ByVal nv As Variant) As String
+Public Function InputToString(ByVal nv As Variant, Optional algo As Variant) As String
 End Function
 
 Public Function DatastructureIsEmpty(ByVal v As Variant) As Boolean

--- a/Source/ITestDev.cls
+++ b/Source/ITestDev.cls
@@ -9,6 +9,18 @@ Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = True
 Option Explicit
 
+Public Property Let Algorithm(ByVal value As Variant)
+End Property
+
+Public Property Get Algorithm() As Variant
+End Property
+
+Public Property Let AlgorithmValueSet(ByVal value As Boolean)
+End Property
+
+Public Property Get AlgorithmValueSet() As Boolean
+End Property
+
 Public Property Let negateValue(ByVal value As Boolean)
 End Property
 
@@ -43,4 +55,10 @@ Public Property Let TestInputIter(ByVal value As String)
 End Property
 
 Public Property Get TestInputIter() As String
+End Property
+
+Public Property Let IsRecurIterFunc(ByVal value As Boolean)
+End Property
+
+Public Property Get IsRecurIterFunc() As Boolean
 End Property

--- a/Source/ITestingFunctionsInfoDev.cls
+++ b/Source/ITestingFunctionsInfoDev.cls
@@ -1,0 +1,35 @@
+VERSION 1.0 CLASS
+BEGIN
+  MultiUse = -1  'True
+END
+Attribute VB_Name = "ITestingFunctionsInfoDev"
+Attribute VB_GlobalNameSpace = False
+Attribute VB_Creatable = False
+Attribute VB_PredeclaredId = False
+Attribute VB_Exposed = True
+Option Explicit
+
+Public Property Get DepthCountOfRecur() As ITestingFunctionsSubInfo
+End Property
+
+Public Property Get DepthCountOfIter() As ITestingFunctionsSubInfo
+End Property
+
+Public Property Get InDataStructureRecur() As ITestingFunctionsSubInfo
+End Property
+
+Public Property Get InDataStructureIter() As ITestingFunctionsSubInfo
+End Property
+
+Public Property Get InDataStructuresRecur() As ITestingFunctionsSubInfo
+End Property
+
+Public Property Get InDataStructuresIter() As ITestingFunctionsSubInfo
+End Property
+
+Public Property Get NestedCountOfRecur() As ITestingFunctionsSubInfo
+End Property
+
+Public Property Get NestedCountOfIter() As ITestingFunctionsSubInfo
+End Property
+

--- a/Source/cExpressions.cls
+++ b/Source/cExpressions.cls
@@ -29,7 +29,9 @@ Private pTestDictCounter As Scripting.Dictionary
 'source: https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/raise-method
 
 Private Const NOT_IMPLEMENTED_ERROR As Long = vbObjectError + 514
-Private Const SPACE_IN_FUNC_NAME As Long = vbObjectError + 515
+Private Const SPACE_IN_FUNC_NAME_ERROR As Long = vbObjectError + 515
+Private Const INVALID_ENUM_VALUE_ERROR As Long = vbObjectError + 516
+Private Const RECUR_ITER_FUNC_ERROR As Long = vbObjectError + 517
 
 Private Property Set IExpressions_setPrinting(ByVal value As cPrinting)
     Set pPrinting = value
@@ -159,25 +161,21 @@ Private Function setStrTestValueStrTestInput(ByVal test As ITest, ByVal Meta As 
         If .ToStrDev Then
             algo = .Algorithm
             
-            If algo = flRecursive Then
+            If algo = flAlgorithm.flRecursive Then
                 testDev.TestValueRecur = test.strTestValue
                 testDev.TestInputRecur = test.StrTestInput
                 
-                pMeta.Tests.Algorithm = flIterative
-                
-                testDev.TestValueIter = IExpressions_InputToString(test.testingValue)
-                testDev.TestInputIter = IExpressions_InputToString(test.testingInput)
-            ElseIf algo = flIterative Then
+                testDev.TestValueIter = IExpressions_InputToString(test.testingValue, flAlgorithm.flIterative)
+                testDev.TestInputIter = IExpressions_InputToString(test.testingInput, flAlgorithm.flIterative)
+            ElseIf algo = flAlgorithm.flIterative Then
                 testDev.TestValueIter = test.strTestValue
                 testDev.TestInputIter = test.StrTestInput
                 
-                pMeta.Tests.Algorithm = flRecursive
-                
-                testDev.TestValueRecur = IExpressions_InputToString(test.testingValue)
-                testDev.TestInputRecur = IExpressions_InputToString(test.testingInput)
+                testDev.TestValueRecur = IExpressions_InputToString(test.testingValue, flAlgorithm.flRecursive)
+                testDev.TestInputRecur = IExpressions_InputToString(test.testingInput, flAlgorithm.flRecursive)
+            Else
+                Err.Raise INVALID_ENUM_VALUE_ERROR, Description:="Enum value is not valid!"
             End If
-            
-            pMeta.Tests.Algorithm = algo
         End If
     End With
     
@@ -196,7 +194,8 @@ Private Sub IExpressions_addToTestAndFluentPath( _
     Optional ByVal higherVal As Variant, _
     Optional ByVal cleanedTestValue As Variant, _
     Optional ByVal cleanedTestInput As Variant, _
-    Optional ByVal Actual As Variant _
+    Optional ByVal Actual As Variant, _
+    Optional ByVal recurIterFunc As Variant _
 )
 
     'Consider refactoring to add a method to sets all test properties if not missing.
@@ -205,8 +204,10 @@ Private Sub IExpressions_addToTestAndFluentPath( _
     'functions as well.
     
     Dim test As ITest
+    Dim testDev As ITestDev
     
     Set test = New cTest
+    Set testDev = test
     
     test.TestValueSet = True
     
@@ -232,6 +233,16 @@ Private Sub IExpressions_addToTestAndFluentPath( _
     End If
         
     Set test = setStrTestValueStrTestInput(test, pMeta, negateValue)
+    
+    If Not VBA.Information.IsMissing(recurIterFunc) Then
+        If recurIterFunc Then
+            testDev.Algorithm = pMeta.Tests.Algorithm
+        
+            testDev.AlgorithmValueSet = pMeta.Tests.AlgorithmValueSet
+            
+            testDev.IsRecurIterFunc = recurIterFunc
+        End If
+    End If
     
     Call IExpressions_addFluentPathNew(test, negateValue)
 
@@ -523,13 +534,33 @@ Private Sub IExpressions_addFluentPathNew(ByVal test As ITest, ByVal negateValue
     Dim fluentElement As Long
     Dim ResultNumber As Long
     Dim testDev As ITestDev
+    Dim recurName As String
+    Dim iterName As String
+    Dim TestingSubInfoRecur As ITestingFunctionsSubInfo
+    Dim TestingSubInfoIter As ITestingFunctionsSubInfo
     
     FluentPath = ""
     fluentElement = 1
     Set testDev = test
+    recurName = ""
+    iterName = ""
     
     If pTestDictCounter.Exists(test.functionName) Then
         Set pTestingSubInfo = pTestingInfo.getTestingFunction(test.functionName)
+        
+        If testDev.IsRecurIterFunc Then
+            recurName = test.functionName & "Recur"
+            iterName = test.functionName & "Iter"
+            If pTestDictCounter.Exists(recurName) And pTestDictCounter.Exists(iterName) Then
+                Set TestingSubInfoRecur = pTestingInfo.getTestingFunction(recurName)
+                Set TestingSubInfoIter = pTestingInfo.getTestingFunction(iterName)
+                
+                TestingSubInfoRecur.Count = TestingSubInfoRecur.Count + 1
+                TestingSubInfoIter.Count = TestingSubInfoIter.Count + 1
+            Else
+                Err.Raise Number:=RECUR_ITER_FUNC_ERROR, Description:="Recursive and/or iterative function does not entries in pTestDictCounter"
+            End If
+        End If
         
         pTestingSubInfo.Count = pTestingSubInfo.Count + 1
         
@@ -543,7 +574,7 @@ Private Sub IExpressions_addFluentPathNew(ByVal test As ITest, ByVal negateValue
             pTestingSubInfo.Unexpected = pTestingSubInfo.Unexpected + 1
         End If
     ElseIf pTestDictCounter.Exists(VBA.Strings.Trim(test.functionName)) Then
-        Err.Raise Number:=SPACE_IN_FUNC_NAME, Description:="Test name not matching in TestDictCounter due to extra space in the function name"
+        Err.Raise Number:=SPACE_IN_FUNC_NAME_ERROR, Description:="Test name not matching in TestDictCounter due to extra space in the function name"
     Else
         Err.Raise Number:=NOT_IMPLEMENTED_ERROR, Description:="Test name not implemented in TestDictCounter"
     End If
@@ -566,7 +597,7 @@ Private Sub IExpressions_addFluentPathNew(ByVal test As ITest, ByVal negateValue
     
 End Sub
 
-Private Function IExpressions_InputToString(ByVal nv As Variant) As String
+Private Function IExpressions_InputToString(ByVal nv As Variant, Optional algo As Variant) As String
     Dim strArgs() As String
     Dim strObj As String
     Dim tempNVTS As String
@@ -574,17 +605,26 @@ Private Function IExpressions_InputToString(ByVal nv As Variant) As String
     Dim elem As Variant
     Dim col As VBA.Collection
     Dim counter As Long
+    Dim method As flAlgorithm
     
     i = 0
     counter = 0
     Set col = New VBA.Collection
     
+    If IsMissing(algo) Then 'a value of 0 is equivalent to
+        method = pMeta.Tests.Algorithm
+    Else
+        method = algo
+    End If
+    
     Select Case True
         Case pMeta.Tests.IsDataStructure(nv)
-            If pMeta.Tests.Algorithm = flRecursive Then
+            If method = flAlgorithm.flRecursive Then
                 tempNVTS = IExpressions_InputToStringRecur(nv)
-            ElseIf pMeta.Tests.Algorithm = flIterative Then
+            ElseIf method = flAlgorithm.flIterative Then
                 tempNVTS = IExpressions_inputToStringIter(nv)
+            Else
+                Err.Raise INVALID_ENUM_VALUE_ERROR, Description:="Enum value is not valid!"
             End If
         Case VBA.Information.IsNull(nv) Or VBA.Information.IsEmpty(nv)
             tempNVTS = VBA.Information.TypeName(nv)

--- a/Source/cTest.cls
+++ b/Source/cTest.cls
@@ -13,6 +13,8 @@ Implements ITest
 Implements ITestDev
 
 Private pAcutal As String
+Private pAlgorithm As Variant
+Private pAlgorithmValueSet As Boolean
 Private pCategory As String
 Private pCleanedTestInput As String
 Private pCleanedTestValue As String
@@ -24,6 +26,7 @@ Private pHasCleanTestValue As Boolean
 Private pHasEmpty As Boolean
 Private pHasNull As Boolean
 Private pHigherVal As Variant
+Private pIsRecurIterFunc As Boolean
 Private pLowerVal As Variant
 Private pNegateValue As Boolean
 Private pResult As Variant
@@ -38,6 +41,13 @@ Private pTestValueIter As String
 Private pTestValueRecur As String
 Private pTestValueSet As Boolean
 Private pTestingValue As Variant
+
+
+Private Const INVALID_ENUM_VALUE_ERROR As Long = vbObjectError + 516
+
+Private Sub Class_Initialize()
+    pAlgorithm = Null
+End Sub
 
 Private Property Let ITest_testingValue(ByVal value As Variant)
     pTestingValue = value
@@ -263,6 +273,34 @@ Private Property Get ITestDev_TestInputIter() As String
     ITestDev_TestInputIter = pTestInputIter
 End Property
 
+Private Property Let ITestDev_Algorithm(ByVal value As Variant)
+    If value = flAlgorithm.flIterative Or value = flAlgorithm.flRecursive Then
+        pAlgorithm = value
+    Else
+        Err.Raise INVALID_ENUM_VALUE_ERROR, Description:="Enum value is not valid!"
+    End If
+End Property
+
+Private Property Get ITestDev_Algorithm() As Variant
+    ITestDev_Algorithm = pAlgorithm
+End Property
+
+Private Property Let ITestDev_AlgorithmValueSet(ByVal value As Boolean)
+    pAlgorithmValueSet = value
+End Property
+
+Private Property Get ITestDev_AlgorithmValueSet() As Boolean
+    ITestDev_AlgorithmValueSet = pAlgorithmValueSet
+End Property
+
+Private Property Let ITestDev_IsRecurIterFunc(ByVal value As Boolean)
+    pIsRecurIterFunc = value
+End Property
+
+Private Property Get ITestDev_IsRecurIterFunc() As Boolean
+    ITestDev_IsRecurIterFunc = pIsRecurIterFunc
+End Property
+
 'PUBLIC PROPERTIES
 
 Public Property Let testingValue(ByVal value As Variant)
@@ -440,3 +478,4 @@ End Property
 Public Property Get Actual() As String
     Actual = ITest_Actual
 End Property
+

--- a/Source/cTestingFunctions.cls
+++ b/Source/cTestingFunctions.cls
@@ -29,6 +29,8 @@ Private pFluentPath As String
 Private pExpressions As IExpressions
 Private pTestValueClean As String
 
+Private Const INVALID_ENUM_VALUE_ERROR As Long = vbObjectError + 516
+
 Private Property Let ITestingFunctions_TestValue(ByVal value As Variant)
     pTestValue = value
     pTestValueSet = True
@@ -142,20 +144,25 @@ Private Function IBeTestFuncs_InDataStructures( _
     If pMeta.Tests.IsDataStructure(testingInput) And pTestValueSet Then
         For i = LBound(testingInput) To UBound(testingInput)
             If pMeta.Tests.IsDataStructure(testingInput(i)) Then
-                If method = flRecursive Then
+                If method = flAlgorithm.flRecursive Then
                     Set col = IBeTestFuncs_getNestedElementsRecur(testingInput)
-                ElseIf method = flIterative Then
+                ElseIf method = flAlgorithm.flIterative Then
                     Set col = IBeTestFuncs_getNestedElementsIter(testingInput)
+                Else
+                    Err.Raise INVALID_ENUM_VALUE_ERROR, Description:="Enum value is not valid!"
                 End If
-            
-                funcVal = IBeTestFuncs_InDataStructure(testingValue, col, negateValue, updateFluentPath:=False)
+                If Not col Is Nothing Then
+                    funcVal = IBeTestFuncs_InDataStructure(testingValue, col, negateValue, updateFluentPath:=False)
+                Else
+                    Err.Raise INVALID_ENUM_VALUE_ERROR, Description:="Enum value is not valid!"
+                End If
             End If
         Next i
     End If
     
     IBeTestFuncs_InDataStructures = funcVal
     
-    Call pExpressions.addToTestAndFluentPath("InDataStructures", funcVal, VBA.Conversion.CBool(negateValue), testingValue, testingInput)
+    Call pExpressions.addToTestAndFluentPath("InDataStructures", funcVal, VBA.Conversion.CBool(negateValue), testingValue, testingInput, recurIterFunc:=True)
     
 End Function
 
@@ -174,30 +181,36 @@ Optional ByVal updateFluentPath As Boolean = False) As Variant
     funcVal = ITestingFunctions_SetDefaultFuncVal
     
     method = pMeta.Tests.Algorithm
-    
+        
     If pMeta.Tests.IsDataStructure(dataStructure) And pTestValueSet Then
         tempBool = False
     
-        If method = flRecursive Then
+        If method = flAlgorithm.flRecursive Then
             Set col = IBeTestFuncs_getNestedElementsRecur(dataStructure)
-        ElseIf method = flIterative Then
+        ElseIf method = flAlgorithm.flIterative Then
             Set col = IBeTestFuncs_getNestedElementsIter(dataStructure)
+        Else
+            Err.Raise INVALID_ENUM_VALUE_ERROR, Description:="Enum value is not valid!"
         End If
-            
-        For Each elem In col
-            If testingValue = elem Then
-                tempBool = True
-                Exit For
-            End If
-        Next elem
         
-        funcVal = tempBool
+        If Not col Is Nothing Then
+            For Each elem In col
+                If testingValue = elem Then
+                    tempBool = True
+                    Exit For
+                End If
+            Next elem
+            
+            funcVal = tempBool
+        Else
+            Err.Raise INVALID_ENUM_VALUE_ERROR, Description:="Enum value is not valid!"
+        End If
     End If
     
     IBeTestFuncs_InDataStructure = funcVal
     
     If updateFluentPath Then
-        Call pExpressions.addToTestAndFluentPath("InDataStructure", funcVal, VBA.Conversion.CBool(negateValue), testingValue, dataStructure)
+        Call pExpressions.addToTestAndFluentPath("InDataStructure", funcVal, VBA.Conversion.CBool(negateValue), testingValue, dataStructure, recurIterFunc:=True)
     End If
     
 End Function
@@ -1457,10 +1470,12 @@ Private Function IHaveTestFuncs_DepthCountOf( _
     method = pMeta.Tests.Algorithm
     
     If pMeta.Tests.IsDataStructure(testingValue) And pTestValueSet Then
-        If method = flRecursive Then
+        If method = flAlgorithm.flRecursive Then
             tempCount = IHaveTestFuncs_getDepthCountRecur(testingValue)
-        ElseIf method = flIterative Then
+        ElseIf method = flAlgorithm.flIterative Then
             tempCount = IHaveTestFuncs_getDepthCountIter(testingValue)
+        Else
+            Err.Raise INVALID_ENUM_VALUE_ERROR, Description:="Enum value is not valid!"
         End If
     
         funcVal = (tempCount = testingInput)
@@ -1468,7 +1483,7 @@ Private Function IHaveTestFuncs_DepthCountOf( _
     
     IHaveTestFuncs_DepthCountOf = funcVal
     
-    Call pExpressions.addToTestAndFluentPath("DepthCountOf", funcVal, VBA.Conversion.CBool(negateValue), testingValue, testingInput)
+    Call pExpressions.addToTestAndFluentPath("DepthCountOf", funcVal, VBA.Conversion.CBool(negateValue), testingValue, testingInput, recurIterFunc:=True)
 End Function
 
 Private Function IHaveTestFuncs_NestedCountOf( _
@@ -1486,10 +1501,12 @@ Private Function IHaveTestFuncs_NestedCountOf( _
     method = pMeta.Tests.Algorithm
     
     If pMeta.Tests.IsDataStructure(testingValue) And pTestValueSet Then
-        If method = flRecursive Then
+        If method = flAlgorithm.flRecursive Then
             Set tempCol = IBeTestFuncs_getNestedElementsRecur(testingValue)
-        ElseIf method = flIterative Then
+        ElseIf method = flAlgorithm.flIterative Then
             Set tempCol = IBeTestFuncs_getNestedElementsIter(testingValue)
+        Else
+            Err.Raise INVALID_ENUM_VALUE_ERROR, Description:="Enum value is not valid!"
         End If
         
         tempCount = tempCol.Count
@@ -1499,6 +1516,6 @@ Private Function IHaveTestFuncs_NestedCountOf( _
     
     IHaveTestFuncs_NestedCountOf = funcVal
     
-    Call pExpressions.addToTestAndFluentPath("NestedCountOf", funcVal, VBA.Conversion.CBool(negateValue), testingValue, testingInput)
+    Call pExpressions.addToTestAndFluentPath("NestedCountOf", funcVal, VBA.Conversion.CBool(negateValue), testingValue, testingInput, recurIterFunc:=True)
 End Function
 

--- a/Source/cTestingFunctionsInfo.cls
+++ b/Source/cTestingFunctionsInfo.cls
@@ -10,6 +10,7 @@ Attribute VB_Exposed = True
 Option Explicit
 
 Implements ITestingFunctionsInfo
+Implements ITestingFunctionsInfoDev
 
 Private pAlphabetic As ITestingFunctionsSubInfo
 Private pAlphanumeric As ITestingFunctionsSubInfo
@@ -45,6 +46,17 @@ Private pSameTypeAs As ITestingFunctionsSubInfo
 Private pSameUniqueElementsAs As ITestingFunctionsSubInfo
 Private pSomething As ITestingFunctionsSubInfo
 Private pStartWith As ITestingFunctionsSubInfo
+
+'ITestingFunctionsInfoDev
+
+Private pDepthCountOfRecur As ITestingFunctionsSubInfo
+Private pDepthCountOfIter As ITestingFunctionsSubInfo
+Private pInDataStructureRecur As ITestingFunctionsSubInfo
+Private pInDataStructureIter As ITestingFunctionsSubInfo
+Private pInDataStructuresRecur As ITestingFunctionsSubInfo
+Private pInDataStructuresIter As ITestingFunctionsSubInfo
+Private pNestedCountOfRecur As ITestingFunctionsSubInfo
+Private pNestedCountOfIter As ITestingFunctionsSubInfo
 
 Private pTestingFunctionsDict As Scripting.Dictionary
 
@@ -188,6 +200,40 @@ Private Function ITestingFunctionsInfo_getTestingFunction(ByVal functionName As 
     Set ITestingFunctionsInfo_getTestingFunction = pTestingFunctionsDict(functionName)
 End Function
 
+'ITestingFunctionsInfoDev settings
+
+Private Property Get ITestingFunctionsInfoDev_DepthCountOfRecur() As ITestingFunctionsSubInfo
+    Set ITestingFunctionsInfoDev_DepthCountOfRecur = pDepthCountOfRecur
+End Property
+
+Private Property Get ITestingFunctionsInfoDev_DepthCountOfIter() As ITestingFunctionsSubInfo
+    Set ITestingFunctionsInfoDev_DepthCountOfIter = pDepthCountOfIter
+End Property
+
+Private Property Get ITestingFunctionsInfoDev_InDataStructureRecur() As ITestingFunctionsSubInfo
+    Set ITestingFunctionsInfoDev_InDataStructureRecur = pInDataStructureRecur
+End Property
+
+Private Property Get ITestingFunctionsInfoDev_InDataStructureIter() As ITestingFunctionsSubInfo
+    Set ITestingFunctionsInfoDev_InDataStructureIter = pInDataStructureIter
+End Property
+
+Private Property Get ITestingFunctionsInfoDev_InDataStructuresRecur() As ITestingFunctionsSubInfo
+    Set ITestingFunctionsInfoDev_InDataStructuresRecur = pInDataStructuresRecur
+End Property
+
+Private Property Get ITestingFunctionsInfoDev_InDataStructuresIter() As ITestingFunctionsSubInfo
+    Set ITestingFunctionsInfoDev_InDataStructuresIter = pInDataStructuresIter
+End Property
+
+Private Property Get ITestingFunctionsInfoDev_NestedCountOfRecur() As ITestingFunctionsSubInfo
+    Set ITestingFunctionsInfoDev_NestedCountOfRecur = pNestedCountOfRecur
+End Property
+
+Private Property Get ITestingFunctionsInfoDev_NestedCountOfIter() As ITestingFunctionsSubInfo
+    Set ITestingFunctionsInfoDev_NestedCountOfIter = pNestedCountOfIter
+End Property
+
 Private Sub ITestingFunctionsInfo_populateDictWithTestFuncInfo()
     pTestingFunctionsDict.Add "Alphabetic", pAlphabetic
     pTestingFunctionsDict.Add "Alphanumeric", pAlphanumeric
@@ -223,6 +269,17 @@ Private Sub ITestingFunctionsInfo_populateDictWithTestFuncInfo()
     pTestingFunctionsDict.Add "SameUniqueElementsAs", pSameUniqueElementsAs
     pTestingFunctionsDict.Add "Something", pSomething
     pTestingFunctionsDict.Add "StartWith", pStartWith
+    
+    'ITestingFunctionsInfoDev
+    
+    pTestingFunctionsDict.Add "DepthCountOfRecur", pDepthCountOfRecur
+    pTestingFunctionsDict.Add "DepthCountOfIter", pDepthCountOfIter
+    pTestingFunctionsDict.Add "InDataStructureRecur", pInDataStructureRecur
+    pTestingFunctionsDict.Add "InDataStructureIter", pInDataStructureIter
+    pTestingFunctionsDict.Add "InDataStructuresRecur", pInDataStructuresRecur
+    pTestingFunctionsDict.Add "InDataStructuresIter", pInDataStructuresIter
+    pTestingFunctionsDict.Add "NestedCountOfRecur", pNestedCountOfRecur
+    pTestingFunctionsDict.Add "NestedCountOfIter", pNestedCountOfIter
 End Sub
 
 Private Sub ITestingFunctionsInfo_initTestingFunctionsInfo()
@@ -306,19 +363,25 @@ Private Function ITestingFunctionsInfo_validateTfiDictCounters(ByVal tfiDict As 
     Dim b As Boolean
     Dim elem As Variant
     Dim testFuncSubInfo As ITestingFunctionsSubInfo
+    Dim recurIterFuncscount As Long
+    
+    recurIterFuncscount = 0
     
     For Each elem In tfiDict.Keys
-        Set testFuncSubInfo = tfiDict(elem)
-        
-        If testFuncSubInfo.Count > 0 Then
-            counter = counter + 1
+        If Not elem Like "*Recur*" And Not elem Like "*Iter*" Then
+            Set testFuncSubInfo = tfiDict(elem)
+            
+            If testFuncSubInfo.Count > 0 Then
+                counter = counter + 1
+            Else
+                Debug.Print "Not in dict: " & elem
+            End If
         Else
-            Debug.Print "Not in dict: " & elem
+            recurIterFuncscount = recurIterFuncscount + 1
         End If
-           
     Next elem
     
-    b = (counter = tfiDict.Count)
+    b = (counter = (tfiDict.Count - recurIterFuncscount))
     ITestingFunctionsInfo_validateTfiDictCounters = b
 End Function
 
@@ -357,6 +420,16 @@ Private Sub initTestingFunctionsSubInfoObjects()
     Set pSameUniqueElementsAs = New cTestingFunctionsSubInfo
     Set pSomething = New cTestingFunctionsSubInfo
     Set pStartWith = New cTestingFunctionsSubInfo
+    
+'ITestingFunctionsInfoDev
+    Set pDepthCountOfRecur = New cTestingFunctionsSubInfo
+    Set pDepthCountOfIter = New cTestingFunctionsSubInfo
+    Set pInDataStructureRecur = New cTestingFunctionsSubInfo
+    Set pInDataStructureIter = New cTestingFunctionsSubInfo
+    Set pInDataStructuresRecur = New cTestingFunctionsSubInfo
+    Set pInDataStructuresIter = New cTestingFunctionsSubInfo
+    Set pNestedCountOfRecur = New cTestingFunctionsSubInfo
+    Set pNestedCountOfIter = New cTestingFunctionsSubInfo
 End Sub
 
 Private Sub Class_Initialize()

--- a/Source/cTests.cls
+++ b/Source/cTests.cls
@@ -9,28 +9,31 @@ Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = True
 Option Explicit
 
+'AlgorithmValueSet
+
 Public Event TestPassed(ByVal test As ITest)
 Public Event TestFailed(ByVal test As ITest)
 Public Event TestCompleted(ByVal test As ITest)
 Public Event TestUnexpected(ByVal test As ITest)
 Public Event DuplicateTest(ByVal test As ITest)
 
-Private pResult As Variant
+Private pAlgorithm As flAlgorithm
+Private pAlgorithmValueSet As Boolean
+Private pApproximateEqual As Boolean
 Private pCol As VBA.Collection
 Private pCount As Long
-Private pTestDictCounter As Scripting.Dictionary
-Private pAlgorithm As flAlgorithm
-Private pToStrDev As Boolean
-Private pApproximateEqual As Boolean
-Private pEpsilon As Double
 Private pDataStructures As VBA.Collection
+Private pEpsilon As Double
 Private pFluentPathDict As Scripting.Dictionary
+Private pResult As Variant
 Private pSkipDupCheck As Boolean
+Private pTestDictCounter As Scripting.Dictionary
+Private pTestingInfo As ITestingFunctionsInfo
+Private pToStrDev As Boolean
 Private pTestStrings As ITestStrings
 
-Private pTestingInfo As ITestingFunctionsInfo
-
 Private Const defaultEpsilon As Double = 0.000001
+Private Const INVALID_ENUM_VALUE_ERROR As Long = vbObjectError + 516
 
 Public Property Get result() As Boolean
     result = pResult
@@ -47,11 +50,21 @@ Attribute NewEnum.VB_UserMemId = -4
 End Property
 
 Public Property Let Algorithm(ByVal value As flAlgorithm)
-    pAlgorithm = value
+    If value = flAlgorithm.flIterative Or value = flAlgorithm.flRecursive Then
+        pAlgorithm = value
+    Else
+        Err.Raise INVALID_ENUM_VALUE_ERROR, Description:="Enum value is not valid!"
+    End If
+    
+    pAlgorithmValueSet = True
 End Property
 
 Public Property Get Algorithm() As flAlgorithm
     Algorithm = pAlgorithm
+End Property
+
+Public Property Get AlgorithmValueSet() As Boolean
+    AlgorithmValueSet = pAlgorithmValueSet
 End Property
 
 Public Property Let ToStrDev(ByVal value As Boolean)


### PR DESCRIPTION
…and InDataStructuresTests with checks to ensure that the flAlgorithm enum maintains its value through the object's lifetime. Added Algorithm and AlgorithmValueSet properties to the Test class. Updated IExpressions_addFluentPathNew to assign values to these new properties. Added an optional parameter to IExpressions_InputToString for flAlgorithm. Refactored IExpressions_InputToString to use this value if it is not missing instead of using the Algorithm property in cTests. Refactored setStrTestValueStrTestInput to no longer update the Algorithm property in cTests. Added a validateRecurIterFluentOfs to validate values in the fluentOf objects used in the recursive and iterative testing functions. Implemented this function in InDataStructureTests, InDataStructuresTests, NestedCountOfTests, and DepthCountOfTests. Updated logic in places that use flAlgorithm to return an INVALID_ENUM_VALUE_ERROR if the value is out of range. Updated tfRecur and tfIter to be module-level objects. Added a call to validateRecurIterFluentOfs to the runEqualPosNegTests method. Updated the Algorithm property in cTests and cTest to check to see if the provided value is within the expected range. Updated InDataStructure and InDataStructures to check to see if the returned collection is not nothing before iterating through it. If it is nothing, then the if statement raises an exception. Added calls to validateRecurIterFluentOfs to the beginning and end of all of the recursive / iterative functions to verify that the expected counts are the same at the start and end of the positive and negative documentation tests. Added a new ITestingFunctionsInfoDev interface. Implemented this interface in cTestingFunctionsInfo. Added a new IsRecurIterFunc property to ITestDev and implemented this property in cTest. Updated IExpressions_addToTestAndFluentPath to set IsRecurIterFunc to true when the function is recursive or iterative. Updated IExpressions_addFluentPathNew with logic to use and increment the recursive and iterative TestingFunctionsSubInfo objects. Updated runMainTests to check the counts and the recursive and iterative functions to ensure that they are identical. Updated validateRecurIterFluentOfs to assert that test object's IsRecurIterFunc property is set to true. Removed several duplicative calls to validateRecurIterFluentOfs. Added a custom error to IExpressions_addFluentPathNew if a recursive function does not have corresponding recursive and/or iterative entries in pTestDictCounter.